### PR TITLE
vayu: Kang libcdfw_remote_api from davinci

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -545,6 +545,7 @@ vendor/bin/xtra-daemon
 -vendor/etc/vintf/manifest/vendor.qti.gnss@4.0-service.xml
 vendor/lib64/hw/vendor.qti.gnss@4.0-impl.so
 vendor/lib64/libcdfw.so
+vendor/lib64/libcdfw_remote_api.so
 vendor/lib64/libdataitems.so
 vendor/lib64/libgdtap.so
 vendor/lib64/libizat_client_api.so


### PR DESCRIPTION
* F linker  : CANNOT LINK EXECUTABLE "xtra-daemon": library "libcdfw_remote_api.so" not found: needed by main executable